### PR TITLE
include api version in oauth access URL

### DIFF
--- a/R/UserSession.R
+++ b/R/UserSession.R
@@ -188,7 +188,7 @@ UserSession <- R6::R6Class(
         endpoint = httr::oauth_endpoint(
           authorize = NULL,
           access = paste0(
-            self$settings$basePath, "/login")),
+            self$settings$basePath, "/api/", self$settings$apiVersion, "/login")),
         app = httr::oauth_app(
           appname = "lookr",
           key = self$settings$clientId,


### PR DESCRIPTION
## issue

currently, we are getting 403 errors when initializing the LookerSDK as suggested in the README with:

`sdk <- LookerSDK$new(configFile = "looker.ini")`

our `looker.ini` file follows the same structure as the example in the readme.

## cause

The access URL in [UserSession.R here](https://github.com/looker-open-source/lookr/blob/master/R/UserSession.R#L191) omits the api version path.

Looker documentation uses the `/api/3.1` path in [the docs here](https://docs.looker.com/reference/api-and-integration/api-reference/v3.1/api-auth#login). The sdk-codegen repo does as well - [e.g. python](https://github.com/looker-open-source/sdk-codegen/blob/4c0f8c9a52ed2e0a40f8c65c5e531fb4f54a0491/python/looker_sdk/rtl/auth_session.py#L151) .

There's a comment ["this would give us parity with the Python SDK, but the AuthApiAuth class is very broken so we can't use it"](https://github.com/looker-open-source/lookr/blob/master/R/UserSession.R#L202). The commented-out usage DOES include the api version in initializing the [ApiClient here](https://github.com/looker-open-source/lookr/blob/master/R/UserSession.R#L36).

you can repro with curl via:

no api version --> returns 403
`curl -I -X POST https://$LOOKER_DOMAIN:19999/login\?client_id\=$CLIENT_ID\&client_secret\=$CLIENT_SECRET`

api version 3.0 --> returns 200
`curl -I -X POST https://$LOOKER_DOMAIN:19999/api/3.0/login\?client_id\=$CLIENT_ID\&client_secret\=$CLIENT_SECRET`

api version 3.1 --> returns 200
`curl -I -X POST https://$LOOKER_DOMAIN:19999/api/3.1/login\?client_id\=$CLIENT_ID\&client_secret\=$CLIENT_SECRET`

## solution

add `/api/<api version>` to the oauth access URL in UserSession.R

## notes

let me know if this is acceptable.

not sure if this is a breaking change with prior API versions.

not sure if there might be some other explanation for the 403s we're seeing.

I'm helping some colleagues debug authentication issues .... this is the first R code I've written!